### PR TITLE
fix: Autoscaling/v2beta1 to autoscaling/v2

### DIFF
--- a/charts/databunker-demo/templates/hpa.yaml
+++ b/charts/databunker-demo/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "databunker-demo.fullname" . }}

--- a/charts/databunker/templates/hpa.yaml
+++ b/charts/databunker/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}


### PR DESCRIPTION
It should be possible to use autoscaling/v2 instead of the v2beta1. 
At least it fails on my cluster, let me know if you need better guards or anything to improve the charts.
