### PR TITLE
fix(deps): update golang.org/x/image to fix medium CVE (OOM via TIFF)

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2 // indirect
 	github.com/ttacon/libphonenumber v1.2.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
-	golang.org/x/image v0.37.0 // indirect
+	golang.org/x/image v0.42.0 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect


### PR DESCRIPTION
## Security Dependency Updates

Resolves Dependabot security alerts by updating vulnerable packages.

### Packages updated
- golang.org/x/image: 0.37.0 → v0.42.0 (CVE: out-of-memory via crafted TIFF; required ≥0.38.0)

### Notes
See the Dependabot alerts in the repository Security tab for full CVE details.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)