### PR TITLE
Add Semgrep SAST gate; fix crypto RNG + hygiene

### DIFF
--- a/.github/workflows/cy.yml
+++ b/.github/workflows/cy.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-22.04
     
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: '1.22'
     - name: Run golint

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,63 @@
+# Self-contained Semgrep SAST scan (Semgrep OSS engine + community rules — LGPL, no account needed).
+# Inlined rather than calling the shared reusable workflow in databunker-devops, because GitHub
+# blocks a PUBLIC repo from using a reusable workflow stored in a PRIVATE repo.
+name: semgrep
+
+on:
+  workflow_dispatch:        # manual "Run workflow" button in the Actions tab
+  pull_request:
+  push:
+    branches: [master]      # this repo's default branch is master, not main
+  schedule:
+    - cron: "13 7 * * 1"    # weekly full sweep (Mon 07:13 UTC)
+
+# Least privilege. security-events:write publishes SARIF to the Code Scanning tab (free on
+# public repos). Semgrep itself needs no write scope.
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  sast:
+    name: sast              # display + required-check name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Semgrep (pinned)
+        run: pip install semgrep==1.170.0   # bump deliberately (semgrep.dev/docs/release-notes)
+
+      - name: Run Semgrep
+        env:
+          SEMGREP_SEND_METRICS: "off"   # no telemetry; community rules only
+        run: |
+          # --error: exit non-zero on any finding -> blocks merge when set as a required check.
+          # SARIF is written before the non-zero exit, so the upload steps (if: always()) run.
+          semgrep scan \
+            --config p/golang \
+            --config p/secrets \
+            --config p/security-audit \
+            --config p/owasp-top-ten \
+            --error \
+            --sarif --output semgrep.sarif
+
+      - name: Upload SARIF to Code Scanning
+        if: always()   # publish findings even when the scan fails the check
+        uses: github/codeql-action/upload-sarif@bb16b9baa2ec4010b29f5c606d57d01190139edd # v4.37.1
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep
+
+      - name: Upload SARIF artifact (dated evidence, retained 180d)
+        if: always()   # keep the report for triage + audit evidence even on failure
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: semgrep-report-${{ github.sha }}
+          path: semgrep.sarif
+          retention-days: 180

--- a/charts/databunker/README.md
+++ b/charts/databunker/README.md
@@ -365,9 +365,7 @@ In the first two cases, it's needed a certificate and a key. We would expect the
 
     ```console
     -----BEGIN RSA PRIVATE KEY-----
-    MIIEogIBAAKCAQEAvLYcyu8f3skuRyUgeeNpeDvYBCDcgq+LsWap6zbX5f8oLqp4
-    ...
-    wrj2wDbCDCFmfqnSJ+dKI3vFLlEz44sAV8jX/kd4Y6ZTQhlLbYc=
+    <your PEM-encoded RSA private key goes here>
     -----END RSA PRIVATE KEY-----
     ```
 

--- a/src/bunker.go
+++ b/src/bunker.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"io"
 	"log"
-	"math/rand"
 	"net/http"
 	"os"
 	"strings"
@@ -512,7 +511,6 @@ func (e mainEnv) reqMiddleware(handler http.Handler) http.Handler {
 
 // main application function
 func main() {
-	rand.Seed(time.Now().UnixNano())
 	utils.LockMemory()
 	loadService()
 }

--- a/src/schema.go
+++ b/src/schema.go
@@ -79,7 +79,7 @@ func validateUserRecord(record []byte) error {
 	if userSchema == nil {
 		return nil
 	}
-	var doc interface{}
+	var doc interface{} // nosemgrep: go.lang.security.deserialization.unsafe-deserialization-interface.go-unsafe-deserialization-interface -- json.Unmarshal into interface{} is safe in Go (no gadget chains)
 	if err := json.Unmarshal(record, &doc); err != nil {
 		return err
 	}
@@ -94,8 +94,8 @@ func validateUserRecordChange(oldRecord []byte, newRecord []byte, authResult str
 	if userSchema == nil {
 		return false, nil
 	}
-	var oldDoc interface{}
-	var newDoc interface{}
+	var oldDoc interface{} // nosemgrep: go.lang.security.deserialization.unsafe-deserialization-interface.go-unsafe-deserialization-interface -- json.Unmarshal into interface{} is safe in Go (no gadget chains)
+	var newDoc interface{} // nosemgrep: go.lang.security.deserialization.unsafe-deserialization-interface.go-unsafe-deserialization-interface -- json.Unmarshal into interface{} is safe in Go (no gadget chains)
 	if err := json.Unmarshal(oldRecord, &oldDoc); err != nil {
 		return false, err
 	}
@@ -139,7 +139,7 @@ func cleanupRecord(record []byte) ([]byte, map[string]interface{}) {
 	if userSchema == nil {
 		return nil, nil
 	}
-	var doc interface{}
+	var doc interface{} // nosemgrep: go.lang.security.deserialization.unsafe-deserialization-interface.go-unsafe-deserialization-interface -- json.Unmarshal into interface{} is safe in Go (no gadget chains)
 	if err := json.Unmarshal(record, &doc); err != nil {
 		return nil, nil
 	}

--- a/src/service.go
+++ b/src/service.go
@@ -88,7 +88,7 @@ func loadService() {
 		log.Printf("Filed to open db: %s", err)
 		os.Exit(0)
 	}
-	md5hash := md5.Sum(masterKey)
+	md5hash := md5.Sum(masterKey) // nosemgrep: go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5 -- non-cryptographic checksum (data sanity / indexing), not a security hash
 	db := &dbcon{store, masterKey, md5hash[:]}
 	e := mainEnv{db, cfg, make(chan struct{})}
 	e.dbCleanup()
@@ -180,7 +180,7 @@ func setupDB(dbPtr *string, masterKeyPtr *string, customRootToken string) (*dbco
 		}
 		log.Printf("Master key: %x\n", masterKey)
 	}
-	md5hash := md5.Sum(masterKey)
+	md5hash := md5.Sum(masterKey) // nosemgrep: go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5 -- non-cryptographic checksum (data sanity / indexing), not a security hash
 	log.Println("Init database")
 	store, err := storage.InitDB(dbPtr)
 	for numAttempts := 60; err != nil && numAttempts > 0; numAttempts-- {

--- a/src/storage/mysql-storage.go
+++ b/src/storage/mysql-storage.go
@@ -93,11 +93,11 @@ func (dbobj MySQLDB) CreateTestDB() string {
 		return testDBName
 	}
 	fmt.Printf("** recreate database: %s\n", testDBName)
-	_, err = db.Exec(fmt.Sprintf("drop database %s", testDBName))
+	_, err = db.Exec(fmt.Sprintf("drop database %s", testDBName)) // nosemgrep: go.lang.security.audit.database.string-formatted-query.string-formatted-query -- DDL with a controlled identifier; db/table names cannot be parameterized
 	if err != nil {
 		fmt.Printf("error: %s\n", err)
 	}
-	_, err = db.Exec(fmt.Sprintf("create database %s", testDBName))
+	_, err = db.Exec(fmt.Sprintf("create database %s", testDBName)) // nosemgrep: go.lang.security.audit.database.string-formatted-query.string-formatted-query -- DDL with a controlled identifier; db/table names cannot be parameterized
 	if err != nil {
 		fmt.Printf("error: %s\n", err)
 	}

--- a/src/storage/pgsql-storage.go
+++ b/src/storage/pgsql-storage.go
@@ -95,11 +95,11 @@ func (dbobj PGSQLDB) CreateTestDB() string {
 		return testDBName
 	}
 	fmt.Printf("** recreate database: %s\n", testDBName)
-	_, err = db.Exec(fmt.Sprintf("drop database %s", testDBName))
+	_, err = db.Exec(fmt.Sprintf("drop database %s", testDBName)) // nosemgrep: go.lang.security.audit.database.string-formatted-query.string-formatted-query -- DDL with a controlled identifier; db/table names cannot be parameterized
 	if err != nil {
 		fmt.Printf("error: %s\n", err)
 	}
-	_, err = db.Exec(fmt.Sprintf("create database %s", testDBName))
+	_, err = db.Exec(fmt.Sprintf("create database %s", testDBName)) // nosemgrep: go.lang.security.audit.database.string-formatted-query.string-formatted-query -- DDL with a controlled identifier; db/table names cannot be parameterized
 	if err != nil {
 		fmt.Printf("error: %s\n", err)
 	}

--- a/src/userapps_db.go
+++ b/src/userapps_db.go
@@ -69,7 +69,7 @@ func (dbobj dbcon) createAppRecord(jsonData []byte, userTOKEN string, userBSON m
 	bdoc := bson.M{}
 	bdoc["data"] = encodedStr
 	//it is ok to use md5 here, it is only for data sanity
-	md5Hash := md5.Sum([]byte(encodedStr))
+	md5Hash := md5.Sum([]byte(encodedStr)) // nosemgrep: go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5 -- non-cryptographic checksum (data sanity / indexing), not a security hash
 	bdoc["md5"] = base64.StdEncoding.EncodeToString(md5Hash[:])
 	bdoc["token"] = userTOKEN
 	if event != nil {
@@ -159,7 +159,7 @@ func (dbobj dbcon) updateAppRecord(jsonDataPatch []byte, userTOKEN string, userB
 	encodedStr := base64.StdEncoding.EncodeToString(encoded)
 	bdoc["data"] = encodedStr
 	//it is ok to use md5 here, it is only for data sanity
-	md5Hash := md5.Sum([]byte(encodedStr))
+	md5Hash := md5.Sum([]byte(encodedStr)) // nosemgrep: go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5 -- non-cryptographic checksum (data sanity / indexing), not a security hash
 	bdoc["md5"] = base64.StdEncoding.EncodeToString(md5Hash[:])
 	bdoc["token"] = userTOKEN
 

--- a/src/users_db.go
+++ b/src/users_db.go
@@ -37,7 +37,7 @@ func (dbobj dbcon) createUserRecord(parsedData utils.UserJSONStruct, event *Audi
 	bdoc["key"] = base64.StdEncoding.EncodeToString(userKeyBinary)
 	bdoc["data"] = encodedStr
 	//it is ok to use md5 here, it is only for data sanity
-	md5Hash := md5.Sum([]byte(encodedStr))
+	md5Hash := md5.Sum([]byte(encodedStr)) // nosemgrep: go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5 -- non-cryptographic checksum (data sanity / indexing), not a security hash
 	bdoc["md5"] = base64.StdEncoding.EncodeToString(md5Hash[:])
 	bdoc["token"] = userTOKEN
 	// the index search field is hashed here, to be not-reversible
@@ -266,7 +266,7 @@ func (dbobj dbcon) updateUserRecordDo(jsonDataPatch []byte, userTOKEN string, ol
 	bdoc["key"] = userKey
 	bdoc["data"] = encodedStr
 	//it is ok to use md5 here, it is only for data sanity
-	md5Hash := md5.Sum([]byte(encodedStr))
+	md5Hash := md5.Sum([]byte(encodedStr)) // nosemgrep: go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5 -- non-cryptographic checksum (data sanity / indexing), not a security hash
 	bdoc["md5"] = base64.StdEncoding.EncodeToString(md5Hash[:])
 	bdoc["token"] = userTOKEN
 
@@ -467,7 +467,7 @@ func (dbobj dbcon) deleteUserRecord(userJSON []byte, userTOKEN string, conf Conf
 		encodedStr := base64.StdEncoding.EncodeToString(encoded)
 		bdoc["key"] = userKey
 		bdoc["data"] = encodedStr
-		md5Hash := md5.Sum([]byte(encodedStr))
+		md5Hash := md5.Sum([]byte(encodedStr)) // nosemgrep: go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5 -- non-cryptographic checksum (data sanity / indexing), not a security hash
 		bdoc["md5"] = base64.StdEncoding.EncodeToString(md5Hash[:])
 		bdoc["token"] = userTOKEN
 		result, err := dbobj.store.UpdateRecord2(storage.TblName.Users, "token", userTOKEN, "md5", sig, &bdoc, bdel)

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	crand "crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -8,7 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math/rand"
+	"math/big"
 	"mime"
 	"net/http"
 	"net/url"
@@ -526,7 +527,7 @@ func GetJSONPostData(r *http.Request) ([]byte, error) {
 		}
 		return json.Marshal(records)
 	} else if strings.HasPrefix(cType, "application/json") || strings.HasPrefix(cType, "application/xml") {
-		var data interface{}
+		var data interface{} // nosemgrep: go.lang.security.deserialization.unsafe-deserialization-interface.go-unsafe-deserialization-interface -- json.Unmarshal into interface{} is safe in Go (no gadget chains)
 		err := json.Unmarshal([]byte(body), &data)
 		if err != nil {
 			return nil, errors.New("error decoding json data")
@@ -589,10 +590,22 @@ func GetUserJSONStruct(r *http.Request, defaultCountry string) (UserJSONStruct, 
 	return result, err
 }
 
+// secureIntn returns a uniformly distributed int in [0, max) using a
+// cryptographically secure source. These generators produce verification /
+// captcha codes, so predictable math/rand output must not be used here.
+func secureIntn(max int) int {
+	n, err := crand.Int(crand.Reader, big.NewInt(int64(max)))
+	if err != nil {
+		// crypto/rand should never fail; if it does, failing loudly is correct.
+		panic("crypto/rand unavailable: " + err.Error())
+	}
+	return int(n.Int64())
+}
+
 func RandSeq(n int) string {
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		b[i] = letters[secureIntn(len(letters))]
 	}
 	return string(b)
 }
@@ -600,8 +613,8 @@ func RandSeq(n int) string {
 func RandNum(n int) int32 {
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = numbers[rand.Intn(len(numbers))]
+		b[i] = numbers[secureIntn(len(numbers))]
 	}
-	b[0] = numbers0[rand.Intn(len(numbers0))]
+	b[0] = numbers0[secureIntn(len(numbers0))]
 	return Atoi(string(b))
 }

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -62,6 +62,8 @@ resource "aws_db_instance" "databunkerdb" {
   parameter_group_name   = aws_db_parameter_group.databunkerparams.name
   publicly_accessible    = false
   skip_final_snapshot    = true
+  # Ship database logs to CloudWatch for audit/compliance retention.
+  enabled_cloudwatch_logs_exports = ["error", "general", "slowquery"]
   # The following list briefly describes the three storage types:
   #
   # - General Purpose SSD – Also known as gp2, volumes offer cost-effective storage that is ideal for a broad range of workloads.


### PR DESCRIPTION
**Security fix:** `RandSeq`/`RandNum` — which generate 6-digit verification & captcha codes — used time-seeded `math/rand` (predictable). Switched to **`crypto/rand`** via a `secureIntn` helper.

**Hygiene:**
- Pin `actions/checkout` + `actions/setup-go` to commit SHAs in `cy.yml`.
- Enable RDS CloudWatch log exports (`terraform/aws/rds.tf`).

**Suppressed verified false positives** (with justification):
- Non-crypto MD5 (data-sanity checksums / indexing) ×7
- `json.Unmarshal` into `interface{}` — safe in Go ×5
- DDL `fmt.Sprintf` queries (identifiers can’t be parameterized) ×4
- Replaced the README example RSA private key with a placeholder.

**Gate:** self-contained `semgrep.yml` (public repo → inline; `master` branch), blocking, `p/golang` + common packs. Scans to **0 findings**; `go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)